### PR TITLE
Set up Shellcheck as a dedicated backend

### DIFF
--- a/pants-plugins/examples/bash/lint/shellcheck/BUILD
+++ b/pants-plugins/examples/bash/lint/shellcheck/BUILD
@@ -1,8 +1,5 @@
 # Copyright 2020 Pants project contributors.
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from examples.bash.target_types import BashTarget
-
-
-def target_types():
-    return [BashTarget]
+# Pants will infer a dependency on `pants-plugins:pantsbuild.pants`.
+python_library()

--- a/pants-plugins/examples/bash/lint/shellcheck/register.py
+++ b/pants-plugins/examples/bash/lint/shellcheck/register.py
@@ -1,0 +1,12 @@
+# Copyright 2020 Pants project contributors.
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+# Note that we use a separate `register.py` than the main `examples/bash/register.py` so that users
+# must opt into activating Shellcheck. We could have instead registered the Shellcheck rules there
+# if we were okay with Shellcheck being activated when the Shell backend is activated.
+
+from examples.bash.lint.shellcheck.rules import rules as shellcheck_rules
+
+
+def rules():
+    return shellcheck_rules()

--- a/pants-plugins/examples/bash/lint/shellcheck/subsystem.py
+++ b/pants-plugins/examples/bash/lint/shellcheck/subsystem.py
@@ -1,0 +1,54 @@
+# Copyright 2020 Pants project contributors.
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+# Refer to https://www.pantsbuild.org/v2.0/docs/rules-api-installing-tools.
+
+from pants.core.util_rules.external_tool import ExternalTool
+from pants.engine.platform import Platform
+from pants.option.custom_types import file_option, shell_str
+
+
+class Shellcheck(ExternalTool):
+    """A linter for shell scripts."""
+
+    options_scope = "shellcheck"
+    default_version = "0.7.1"
+    default_known_versions = [
+        "0.7.1|darwin|b080c3b659f7286e27004aa33759664d91e15ef2498ac709a452445d47e3ac23|1348272",
+        "0.7.1|linux|64f17152d96d7ec261ad3086ed42d18232fcb65148b44571b564d688269d36c8|1443836",
+    ]
+
+    @classmethod
+    def register_options(cls, register):
+        super().register_options(register)
+        register(
+            "--skip",
+            type=bool,
+            default=False,
+            help="Don't use Shellcheck when running `./pants lint`.",
+        )
+        register(
+            "--args",
+            type=list,
+            member_type=shell_str,
+            help=(
+                "Arguments to pass directly to Shellcheck, e.g. `--shellcheck-args='-e SC20529'`.'"
+            ),
+        )
+        register(
+            "--config",
+            type=list,
+            member_type=file_option,
+            advanced=True,
+            help="Path to `.shellcheckrc`. This must be relative to the build root.",
+        )
+
+    def generate_url(self, plat: Platform) -> str:
+        plat_str = "linux" if plat == Platform.linux else "darwin"
+        return (
+            f"https://github.com/koalaman/shellcheck/releases/download/v{self.options.version}/"
+            f"shellcheck-v{self.options.version}.{plat_str}.x86_64.tar.xz"
+        )
+
+    def generate_exe(self, _: Platform) -> str:
+        return f"./shellcheck-v{self.options.version}/shellcheck"

--- a/pants.toml
+++ b/pants.toml
@@ -19,6 +19,7 @@ backend_packages = [
   # This will activate `pants-plugins/examples/bash/register.py` so that we can use its
   # functionality in our repository.
   "examples.bash",
+  "examples.bash.lint.shellcheck",
 ]
 
 [source]


### PR DESCRIPTION
We'll soon be adding Shellfmt as an example formatter. For formatters, you must set up some boilerplate for your language if it doesn't yet have it, such as defining `BashFormatterTargets`. We don't want that to live in the same file as `shellfmt.py` because it would be too noisy. So, we're going to want a dedicated folder for shellfmt, which means shellcheck should be similar.

Given that we want to eventually publish this example repo, this is also useful behavior to make users opt-in to Shellcheck, rather than being automatically activated.