### PR TITLE
Add a naive `binary` implementation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,3 +20,6 @@ install:
 script:
   - ./pants lint '::'
   - ./pants test '::'
+  # Smoke test that our `binary` implementation runs successfully.
+  - ./pants binary '::'
+

--- a/build-support/python/BUILD
+++ b/build-support/python/BUILD
@@ -1,4 +1,7 @@
 # Copyright 2020 Pants project contributors.
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-bash(name="scripts")
+bash_binary(
+  name="setup_venv",
+  sources=["setup_venv.sh"],
+)

--- a/pants-plugins/examples/bash/create_binary.py
+++ b/pants-plugins/examples/bash/create_binary.py
@@ -26,6 +26,12 @@ class BashBinaryFieldSet(BinaryFieldSet):
 
 @rule(level=LogLevel.DEBUG)
 async def create_bash_binary(field_set: BashBinaryFieldSet) -> CreatedBinary:
+    # This `binary` implementation will simply create a `.zip` file with all the relevant files
+    # included. The user must then unzip the file and run the relevant file.
+    #
+    # A more robust `binary` implementation will create a single file that is runnable, such as a
+    # PEX file or JAR file.
+
     zip_program_paths = await Get(
         BinaryPaths,
         BinaryPathRequest(binary_name="zip", search_path=["/bin", "/usr/bin"]),

--- a/pants-plugins/examples/bash/create_binary.py
+++ b/pants-plugins/examples/bash/create_binary.py
@@ -1,0 +1,72 @@
+# Copyright 2020 Pants project contributors.
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from dataclasses import dataclass
+
+from pants.core.goals.binary import BinaryFieldSet, CreatedBinary
+from pants.core.goals.run import RunRequest
+from pants.core.util_rules.source_files import SourceFiles, SourceFilesRequest
+from pants.engine.addresses import Addresses
+from pants.engine.process import BinaryPathRequest, BinaryPaths, Process, ProcessResult
+from pants.engine.rules import Get, collect_rules, rule
+from pants.engine.target import Dependencies, TransitiveTargets
+from pants.engine.unions import UnionRule
+from pants.util.logging import LogLevel
+
+from examples.bash.target_types import BashBinarySources, BashSources
+
+
+@dataclass(frozen=True)
+class BashBinaryFieldSet(BinaryFieldSet):
+    required_fields = (BashBinarySources,)
+
+    sources: BashBinarySources
+    dependencies: Dependencies
+
+
+@rule(level=LogLevel.DEBUG)
+async def create_bash_binary(field_set: BashBinaryFieldSet) -> CreatedBinary:
+    zip_program_paths = await Get(
+        BinaryPaths,
+        BinaryPathRequest(binary_name="zip", search_path=["/bin", "/usr/bin"]),
+    )
+    if not zip_program_paths.first_path:
+        raise ValueError(
+            "Could not find the `zip` program on `/bin` or `/usr/bin`, so cannot create a binary "
+            f"for {field_set.address}."
+        )
+
+    transitive_targets = await Get(TransitiveTargets, Addresses([field_set.address]))
+    sources = await Get(
+        SourceFiles,
+        SourceFilesRequest(
+            tgt[BashSources]
+            for tgt in transitive_targets.closure
+            if tgt.has_field(BashSources)
+        ),
+    )
+
+    output_filename = f"{field_set.address.target_name}.zip"
+    result = await Get(
+        ProcessResult,
+        Process(
+            argv=(
+                zip_program_paths.first_path,
+                output_filename,
+                *sources.snapshot.files,
+            ),
+            input_digest=sources.snapshot.digest,
+            description=f"Zip {field_set.address} and its dependencies.",
+            output_files=(output_filename,),
+        ),
+    )
+    return CreatedBinary(result.output_digest, binary_name=output_filename)
+
+
+@rule
+def run_bash_binary(_: BashBinaryFieldSet) -> RunRequest:
+    raise NotImplementedError("Run does not yet work on Bash targets.")
+
+
+def rules():
+    return (*collect_rules(), UnionRule(BinaryFieldSet, BashBinaryFieldSet))

--- a/pants-plugins/examples/bash/register.py
+++ b/pants-plugins/examples/bash/register.py
@@ -1,8 +1,13 @@
 # Copyright 2020 Pants project contributors.
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from examples.bash.target_types import BashTarget
+from examples.bash import create_binary
+from examples.bash.target_types import BashBinary, BashLibrary
 
 
 def target_types():
-    return [BashTarget]
+    return [BashBinary, BashLibrary]
+
+
+def rules():
+    return [*create_binary.rules()]

--- a/pants-plugins/examples/bash/target_types.py
+++ b/pants-plugins/examples/bash/target_types.py
@@ -20,6 +20,7 @@ class BashLibrary(Target):
 
 
 class BashBinarySources(BashSources):
+    required = True
     expected_num_files = 1
 
 

--- a/pants-plugins/examples/bash/target_types.py
+++ b/pants-plugins/examples/bash/target_types.py
@@ -7,9 +7,24 @@ from pants.engine.target import COMMON_TARGET_FIELDS, Dependencies, Sources, Tar
 
 
 class BashSources(Sources):
-    default = ("*.sh",)
+    # Normally, we would add `expected_file_extensions = ('.sh',)`, but Bash scripts don't need a
+    # file extension, so we don't use this.
+    pass
 
 
-class BashTarget(Target):
-    alias = "bash"
+class BashLibrary(Target):
+    """Bash util code that is not directly run."""
+
+    alias = "bash_library"
     core_fields = (*COMMON_TARGET_FIELDS, Dependencies, BashSources)
+
+
+class BashBinarySources(BashSources):
+    expected_num_files = 1
+
+
+class BashBinary(Target):
+    """A Bash file that may be directly run."""
+
+    alias = "bash_binary"
+    core_fields = (*COMMON_TARGET_FIELDS, Dependencies, BashBinarySources)


### PR DESCRIPTION
Corresponds to https://www.pantsbuild.org/v2.0/docs/plugins-run-goal.

Unlike Pex, running `dist/<new_bash_binary>` will not actually run the script, as there is no equivalent to Pex for Bash that we know of. Instead, we simply create a Zip file with all the relevant sources included. The onus is then on the user to unzip the file and run whatever script they want. 

While not as useful as Pex, this implementation still is a solid example for how `binary` works. It's easier to follow than our Pex implementation, which is riddled with our Python abstractions like `TwoStepPexRequest`.