### PR TITLE
Add a `run` implementation for Bash

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,6 @@ install:
 script:
   - ./pants lint '::'
   - ./pants test '::'
-  # Smoke test that our `binary` implementation runs successfully.
+  # Smoke test that our `binary` and `run` implementations run successfully.
   - ./pants binary '::'
-
+  - ./pants run build-support/python/setup_venv.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,4 +22,4 @@ script:
   - ./pants test '::'
   # Smoke test that our `binary` and `run` implementations run successfully.
   - ./pants binary '::'
-  - ./pants run build-support/python/setup_venv.sh
+  - ./pants --no-pantsd run build-support/python/setup_venv.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,5 @@ install:
 script:
   - ./pants lint '::'
   - ./pants test '::'
-  # Smoke test that our `binary` and `run` implementations run successfully.
+  # Smoke test that our `binary` implementation runs successfully.
   - ./pants binary '::'
-  - ./pants --no-pantsd run build-support/python/setup_venv.sh

--- a/build-support/python/setup_venv.sh
+++ b/build-support/python/setup_venv.sh
@@ -5,14 +5,10 @@
 # This script is useful to set up a virtual environment so that IDEs understand the Python code.
 # See https://www.pantsbuild.org/docs/python-third-party-dependencies.
 
-set -x
-
 PYTHON_BIN=python3.6
 VIRTUALENV=build-support/python/.venv
 PIP="${VIRTUALENV}/bin/pip"
 
 "${PYTHON_BIN}" -m venv "${VIRTUALENV}"
-ls -A "${VIRTUALENV}"
-ls -A "${VIRTUALENV}"/bin
 "${PIP}" install pip --upgrade
 "${PIP}" install -r <(./pants dependencies --type=3rdparty ::)

--- a/build-support/python/setup_venv.sh
+++ b/build-support/python/setup_venv.sh
@@ -5,6 +5,8 @@
 # This script is useful to set up a virtual environment so that IDEs understand the Python code.
 # See https://www.pantsbuild.org/docs/python-third-party-dependencies.
 
+set -x
+
 PYTHON_BIN=python3.6
 VIRTUALENV=build-support/python/.venv
 PIP="${VIRTUALENV}/bin/pip"

--- a/build-support/python/setup_venv.sh
+++ b/build-support/python/setup_venv.sh
@@ -12,5 +12,7 @@ VIRTUALENV=build-support/python/.venv
 PIP="${VIRTUALENV}/bin/pip"
 
 "${PYTHON_BIN}" -m venv "${VIRTUALENV}"
+ls -A "${VIRTUALENV}"
+ls -A "${VIRTUALENV}"/bin
 "${PIP}" install pip --upgrade
 "${PIP}" install -r <(./pants dependencies --type=3rdparty ::)

--- a/pants-plugins/examples/bash/create_binary.py
+++ b/pants-plugins/examples/bash/create_binary.py
@@ -4,7 +4,6 @@
 from dataclasses import dataclass
 
 from pants.core.goals.binary import BinaryFieldSet, CreatedBinary
-from pants.core.goals.run import RunRequest
 from pants.core.util_rules.source_files import SourceFiles, SourceFilesRequest
 from pants.engine.addresses import Addresses
 from pants.engine.process import BinaryPathRequest, BinaryPaths, Process, ProcessResult
@@ -67,11 +66,6 @@ async def create_bash_binary(field_set: BashBinaryFieldSet) -> CreatedBinary:
         ),
     )
     return CreatedBinary(result.output_digest, binary_name=output_filename)
-
-
-@rule
-def run_bash_binary(_: BashBinaryFieldSet) -> RunRequest:
-    raise NotImplementedError("Run does not yet work on Bash targets.")
 
 
 def rules():

--- a/pants-plugins/examples/bash/register.py
+++ b/pants-plugins/examples/bash/register.py
@@ -1,7 +1,7 @@
 # Copyright 2020 Pants project contributors.
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from examples.bash import create_binary
+from examples.bash import create_binary, run_binary
 from examples.bash.target_types import BashBinary, BashLibrary
 
 
@@ -10,4 +10,4 @@ def target_types():
 
 
 def rules():
-    return [*create_binary.rules()]
+    return [*create_binary.rules(), *run_binary.rules()]

--- a/pants-plugins/examples/bash/run_binary.py
+++ b/pants-plugins/examples/bash/run_binary.py
@@ -1,0 +1,54 @@
+# Copyright 2020 Pants project contributors.
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from pants.core.goals.run import RunRequest
+from pants.core.target_types import FilesSources, ResourcesSources
+from pants.core.util_rules.source_files import SourceFiles, SourceFilesRequest
+from pants.engine.addresses import Addresses
+from pants.engine.process import BinaryPathRequest, BinaryPaths
+from pants.engine.rules import Get, MultiGet, collect_rules, rule
+from pants.engine.target import Sources, TransitiveTargets
+from pants.util.logging import LogLevel
+
+from examples.bash.create_binary import BashBinaryFieldSet
+from examples.bash.target_types import BashSources
+
+
+@rule(level=LogLevel.DEBUG)
+async def run_bash_binary(field_set: BashBinaryFieldSet) -> RunRequest:
+    bash_program_paths = await Get(
+        BinaryPaths,
+        BinaryPathRequest(binary_name="bash", search_path=["/bin", "/usr/bin"]),
+    )
+    if not bash_program_paths.first_path:
+        raise ValueError(
+            "Could not find the `bash` program on `/bin` or `/usr/bin`, so cannot run "
+            f"{field_set.address}."
+        )
+
+    transitive_targets = await Get(TransitiveTargets, Addresses([field_set.address]))
+
+    binary_sources_request = Get(SourceFiles, SourceFilesRequest([field_set.sources]))
+    all_sources_request = Get(
+        SourceFiles,
+        SourceFilesRequest(
+            (tgt.get(Sources) for tgt in transitive_targets.closure),
+            for_sources_types=(BashSources, FilesSources, ResourcesSources),
+        ),
+    )
+    binary_sources, all_sources = await MultiGet(
+        binary_sources_request, all_sources_request
+    )
+
+    # Note that `BashBinarySources` will have already validated that there is exactly one file in
+    # the sources field.
+    script_name = binary_sources.files[0]
+
+    return RunRequest(
+        digest=all_sources.snapshot.digest,
+        args=[bash_program_paths.first_path, script_name],
+    )
+
+
+def rules():
+    return collect_rules()


### PR DESCRIPTION
Corresponds to https://www.pantsbuild.org/v2.0/docs/plugins-run-goal (still WIP).

Now Pants knows how to run arbitrary Bash scripts. Note that it will ignore the shebang and always run the equivalent `/path/to/bash script.sh`.

This implementation is extremely simplistic, as there isn't much to running a Bash script.

Originally, this implementation was going to add a `--bash-setup-executable-search-paths` option, but it looks like that is not necessary for `InteractiveProcess`; the `env` is not hermetic.