### PR TITLE
Add a `test` implementation with `shunit2`

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,5 @@
 An example repository to demonstrate creating a plugin, specifically a plugin to add support for Bash.
 
 See [pantsbuild.org/v2.0/docs/plugins-overview](https://www.pantsbuild.org/v2.0/docs/plugins-overview) for more detailed documentation.
+
+The plugin is written in `pants-plugins/examples/bash`.

--- a/pants-plugins/examples/bash/bash_setup.py
+++ b/pants-plugins/examples/bash/bash_setup.py
@@ -67,12 +67,12 @@ class BashProgram:
 
 
 @rule(desc="Find Bash", level=LogLevel.DEBUG)
-async def run_bash_binary() -> BashProgram:
+async def run_bash_binary(bash_setup: BashSetup) -> BashProgram:
     # We expect Bash to already be installed. See
     # https://www.pantsbuild.org/v2.0/docs/rules-api-installing-tools.
     bash_program_paths = await Get(
         BinaryPaths,
-        BinaryPathRequest(binary_name="bash", search_path=["/bin", "/usr/bin"]),
+        BinaryPathRequest(binary_name="bash", search_path=bash_setup.executable_search_path),
     )
     if not bash_program_paths.first_path:
         raise EnvironmentError(

--- a/pants-plugins/examples/bash/bash_setup.py
+++ b/pants-plugins/examples/bash/bash_setup.py
@@ -72,7 +72,9 @@ async def run_bash_binary(bash_setup: BashSetup) -> BashProgram:
     # https://www.pantsbuild.org/v2.0/docs/rules-api-installing-tools.
     bash_program_paths = await Get(
         BinaryPaths,
-        BinaryPathRequest(binary_name="bash", search_path=bash_setup.executable_search_path),
+        BinaryPathRequest(
+            binary_name="bash", search_path=bash_setup.executable_search_path
+        ),
     )
     if not bash_program_paths.first_path:
         raise EnvironmentError(

--- a/pants-plugins/examples/bash/bash_setup.py
+++ b/pants-plugins/examples/bash/bash_setup.py
@@ -1,0 +1,85 @@
+# Copyright 2020 Pants project contributors.
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+"""Common setup for the Bash plugin, similar to Pants's `[python-setup]`
+subsystem."""
+
+import os
+from dataclasses import dataclass
+from typing import Tuple
+
+from pants.engine.process import BinaryPathRequest, BinaryPaths
+from pants.engine.rules import Get, collect_rules, rule
+from pants.option.subsystem import Subsystem
+from pants.util.frozendict import FrozenDict
+from pants.util.logging import LogLevel
+from pants.util.ordered_set import OrderedSet
+from pants.util.strutil import create_path_env_var
+
+
+# See https://www.pantsbuild.org/v2.0/docs/rules-api-subsystems.
+class BashSetup(Subsystem):
+    """Common setup for the Bash plugin."""
+
+    options_scope = "bash-setup"
+
+    @classmethod
+    def register_options(cls, register):
+        register(
+            "--executable-search-paths",
+            type=list,
+            member_type=str,
+            default=["<PATH>"],
+            metavar="<binary-paths>",
+            help=(
+                "The PATH value that will be used by subprocesses spawned by the Bash plugin. The "
+                "special string '<PATH>' will expand to the contents of the PATH env var."
+            ),
+        )
+
+    @property
+    def executable_search_path(self) -> Tuple[str, ...]:
+        result = OrderedSet()
+        for entry in self.options.executable_search_paths:
+            if entry == "<PATH>":
+                path = os.environ.get("PATH")
+                if path:
+                    for path_entry in path.split(os.pathsep):
+                        result.add(path_entry)
+            else:
+                result.add(entry)
+        return tuple(result)
+
+    @property
+    def env_dict(self) -> FrozenDict[str, str]:
+        """Setup for the `env` for `Process`es that run Bash.
+
+        Call sites must opt into using this value by requesting
+        `BashSetup` as a parameter to their rule, then setting
+        `env=bash_setup.env_dict` for any relevant `Process.`
+        """
+        return FrozenDict({"PATH": create_path_env_var(self.executable_search_path)})
+
+
+@dataclass(frozen=True)
+class BashProgram:
+    exe: str
+
+
+@rule(desc="Find Bash", level=LogLevel.DEBUG)
+async def run_bash_binary() -> BashProgram:
+    # We expect Bash to already be installed. See
+    # https://www.pantsbuild.org/v2.0/docs/rules-api-installing-tools.
+    bash_program_paths = await Get(
+        BinaryPaths,
+        BinaryPathRequest(binary_name="bash", search_path=["/bin", "/usr/bin"]),
+    )
+    if not bash_program_paths.first_path:
+        raise EnvironmentError(
+            "Could not find the `bash` program on `/bin` or `/usr/bin`, so this plugin cannot work."
+        )
+    return BashProgram(bash_program_paths.first_path)
+
+
+def rules():
+    return collect_rules()

--- a/pants-plugins/examples/bash/bash_setup.py
+++ b/pants-plugins/examples/bash/bash_setup.py
@@ -78,7 +78,10 @@ async def run_bash_binary(bash_setup: BashSetup) -> BashProgram:
     )
     if not bash_program_paths.first_path:
         raise EnvironmentError(
-            "Could not find the `bash` program on `/bin` or `/usr/bin`, so this plugin cannot work."
+            "Could not find the `bash` program on search paths "
+            f"{list(bash_setup.executable_search_path)}. Please check that `bash` is installed and "
+            "possibly modify the option `executable_search_paths` in the `[bash-setup]` options "
+            "scope."
         )
     return BashProgram(bash_program_paths.first_path)
 

--- a/pants-plugins/examples/bash/create_binary.py
+++ b/pants-plugins/examples/bash/create_binary.py
@@ -49,8 +49,10 @@ async def create_bash_binary(
     )
     if not zip_program_paths.first_path:
         raise EnvironmentError(
-            "Could not find the `zip` program on `/bin` or `/usr/bin`, so cannot create a binary "
-            f"for {field_set.address}."
+            f"Could not find the `zip` program on search paths "
+            f"{list(bash_setup.executable_search_path)}, so cannot create a binary for "
+            f"{field_set.address}. Please check that `zip` iss installed and possibly modify the "
+            "option `executable_search_paths` in the `[bash-setup]` options scope."
         )
 
     # We need to include all relevant transitive dependencies in the zip. See

--- a/pants-plugins/examples/bash/create_binary.py
+++ b/pants-plugins/examples/bash/create_binary.py
@@ -1,14 +1,24 @@
 # Copyright 2020 Pants project contributors.
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+"""See https://www.pantsbuild.org/v2.0/docs/plugins-binary-goal.
+
+This plugin will simply create a `.zip` file with all the relevant files included. The user must
+then unzip the file and run the relevant file.
+
+A more robust `binary` implementation will create a single file that is runnable, such as a
+PEX file or JAR file.
+"""
+
 from dataclasses import dataclass
 
 from pants.core.goals.binary import BinaryFieldSet, CreatedBinary
+from pants.core.target_types import FilesSources, ResourcesSources
 from pants.core.util_rules.source_files import SourceFiles, SourceFilesRequest
 from pants.engine.addresses import Addresses
 from pants.engine.process import BinaryPathRequest, BinaryPaths, Process, ProcessResult
 from pants.engine.rules import Get, collect_rules, rule
-from pants.engine.target import Dependencies, TransitiveTargets
+from pants.engine.target import Dependencies, Sources, TransitiveTargets
 from pants.engine.unions import UnionRule
 from pants.util.logging import LogLevel
 
@@ -25,12 +35,8 @@ class BashBinaryFieldSet(BinaryFieldSet):
 
 @rule(level=LogLevel.DEBUG)
 async def create_bash_binary(field_set: BashBinaryFieldSet) -> CreatedBinary:
-    # This `binary` implementation will simply create a `.zip` file with all the relevant files
-    # included. The user must then unzip the file and run the relevant file.
-    #
-    # A more robust `binary` implementation will create a single file that is runnable, such as a
-    # PEX file or JAR file.
-
+    # We first locate the `zip` program using `BinaryPaths`. See
+    # https://www.pantsbuild.org/v2.0/docs/rules-api-installing-tools.
     zip_program_paths = await Get(
         BinaryPaths,
         BinaryPathRequest(binary_name="zip", search_path=["/bin", "/usr/bin"]),
@@ -41,13 +47,14 @@ async def create_bash_binary(field_set: BashBinaryFieldSet) -> CreatedBinary:
             f"for {field_set.address}."
         )
 
+    # We need to include all relevant transitive dependencies in the zip. See
+    # https://www.pantsbuild.org/v2.0/docs/rules-api-and-target-api.
     transitive_targets = await Get(TransitiveTargets, Addresses([field_set.address]))
     sources = await Get(
         SourceFiles,
         SourceFilesRequest(
-            tgt[BashSources]
-            for tgt in transitive_targets.closure
-            if tgt.has_field(BashSources)
+            (tgt.get(Sources) for tgt in transitive_targets.closure),
+            for_sources_types=(BashSources, FilesSources, ResourcesSources),
         ),
     )
 

--- a/pants-plugins/examples/bash/create_binary.py
+++ b/pants-plugins/examples/bash/create_binary.py
@@ -35,13 +35,17 @@ class BashBinaryFieldSet(BinaryFieldSet):
 
 
 @rule(level=LogLevel.DEBUG)
-async def create_bash_binary(field_set: BashBinaryFieldSet, bash_setup: BashSetup) -> CreatedBinary:
+async def create_bash_binary(
+    field_set: BashBinaryFieldSet, bash_setup: BashSetup
+) -> CreatedBinary:
     # We first locate the `zip` program using `BinaryPaths`. We use the option
     # `--bash-executable-search-paths` to determine which paths to search, such as `/bin` and
     # `/usr/bin`. See https://www.pantsbuild.org/v2.0/docs/rules-api-installing-tools.
     zip_program_paths = await Get(
         BinaryPaths,
-        BinaryPathRequest(binary_name="zip", search_path=bash_setup.executable_search_path),
+        BinaryPathRequest(
+            binary_name="zip", search_path=bash_setup.executable_search_path
+        ),
     )
     if not zip_program_paths.first_path:
         raise EnvironmentError(

--- a/pants-plugins/examples/bash/lint/bash_formatters.py
+++ b/pants-plugins/examples/bash/lint/bash_formatters.py
@@ -1,6 +1,13 @@
 # Copyright 2020 Pants project contributors.
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+"""Setup for formatters for Bash.
+
+You need to have this file for each distinct "language", such as Python or Java. This allows Pants
+to group all relevant formatters together, such as all Bash formatters together and all Python
+formatters together. See https://www.pantsbuild.org/v2.0/docs/plugins-fmt-goal.
+"""
+
 from dataclasses import dataclass
 from typing import Iterable, List, Type
 

--- a/pants-plugins/examples/bash/lint/shellcheck/register.py
+++ b/pants-plugins/examples/bash/lint/shellcheck/register.py
@@ -1,9 +1,14 @@
 # Copyright 2020 Pants project contributors.
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-# Note that we use a separate `register.py` than the main `examples/bash/register.py` so that users
-# must opt into activating Shellcheck. We could have instead registered the Shellcheck rules there
-# if we were okay with Shellcheck being activated when the Shell backend is activated.
+"""The entry point for our `examples.bash.lint.shellcheck` plugin.
+
+See https://www.pantsbuild.org/v2.0/docs/plugins-overview.
+
+Note that we use a separate `register.py` than the main `examples/bash/register.py` so that users
+must opt into activating Shellcheck. We could have instead registered the Shellcheck rules there
+if we were okay with Shellcheck being activated when the Bash backend is activated.
+"""
 
 from examples.bash.lint.shellcheck.rules import rules as shellcheck_rules
 

--- a/pants-plugins/examples/bash/lint/shellcheck/register.py
+++ b/pants-plugins/examples/bash/lint/shellcheck/register.py
@@ -7,7 +7,7 @@ See https://www.pantsbuild.org/v2.0/docs/plugins-overview.
 
 Note that we use a separate `register.py` than the main `examples/bash/register.py` so that users
 must opt into activating Shellcheck. We could have instead registered the Shellcheck rules there
-if we were okay with Shellcheck being activated when the Bash backend is activated.
+if we were okay with Shellcheck always being activated when the Bash backend is activated.
 """
 
 from examples.bash.lint.shellcheck.rules import rules as shellcheck_rules

--- a/pants-plugins/examples/bash/lint/shellcheck/subsystem.py
+++ b/pants-plugins/examples/bash/lint/shellcheck/subsystem.py
@@ -1,7 +1,12 @@
 # Copyright 2020 Pants project contributors.
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-# Refer to https://www.pantsbuild.org/v2.0/docs/rules-api-installing-tools.
+"""Options for the Shellcheck linter.
+
+We use `ExternalTool` so that we can easily install the pre-compiled binary. See
+https://www.pantsbuild.org/v2.0/docs/rules-api-installing-tools and
+https://www.pantsbuild.org/v2.0/docs/rules-api-subsystems.
+"""
 
 from pants.core.util_rules.external_tool import ExternalTool
 from pants.engine.platform import Platform

--- a/pants-plugins/examples/bash/lint/shfmt/register.py
+++ b/pants-plugins/examples/bash/lint/shfmt/register.py
@@ -1,9 +1,14 @@
 # Copyright 2020 Pants project contributors.
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-# Note that we use a separate `register.py` than the main `examples/bash/register.py` so that users
-# must opt into activating Shellcheck. We could have instead registered the Shellcheck rules there
-# if we were okay with Shellcheck being activated when the Shell backend is activated.
+"""The entry point for our `examples.bash.lint.shfmt` plugin.
+
+See https://www.pantsbuild.org/v2.0/docs/plugins-overview.
+
+Note that we use a separate `register.py` than the main `examples/bash/register.py` so that users
+must opt into activating shfmt. We could have instead registered the shfmt rules there
+if we were okay with shfmt being activated when the Bash backend is activated.
+"""
 
 from examples.bash.lint import bash_formatters
 from examples.bash.lint.shfmt.rules import rules as shfmt_rules

--- a/pants-plugins/examples/bash/lint/shfmt/rules.py
+++ b/pants-plugins/examples/bash/lint/shfmt/rules.py
@@ -66,7 +66,7 @@ async def setup_shfmt(setup_request: SetupRequest, shfmt: Shfmt) -> Setup:
 
     # If the user specified `--shfmt-config`, we must search for the file they specified with
     # `PathGlobs` to include it in the `input_digest`. We error if the file cannot be found.
-    # https://www.pantsbuild.org/v2.0/docs/rules-api-file-system.
+    # See https://www.pantsbuild.org/v2.0/docs/rules-api-file-system.
     config_digest_request = Get(
         Digest,
         PathGlobs(

--- a/pants-plugins/examples/bash/lint/shfmt/rules.py
+++ b/pants-plugins/examples/bash/lint/shfmt/rules.py
@@ -1,7 +1,13 @@
 # Copyright 2020 Pants project contributors.
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-# Refer to https://www.pantsbuild.org/v2.0/docs/plugins-fmt-goal.
+"""See https://www.pantsbuild.org/v2.0/docs/plugins-fmt-goal.
+
+This plugin installs shfmt, then runs it on the input files.
+
+It provides rules for both `lint` and `fmt` so that shfmt is used with both goals. To deduplicate,
+we have a common `Setup` type and a rule to set up shfmt.
+"""
 
 from dataclasses import dataclass
 
@@ -60,6 +66,7 @@ async def setup_shfmt(setup_request: SetupRequest, shfmt: Shfmt) -> Setup:
 
     # If the user specified `--shfmt-config`, we must search for the file they specified with
     # `PathGlobs` to include it in the `input_digest`. We error if the file cannot be found.
+    # https://www.pantsbuild.org/v2.0/docs/rules-api-file-system.
     config_digest_request = Get(
         Digest,
         PathGlobs(
@@ -88,6 +95,8 @@ async def setup_shfmt(setup_request: SetupRequest, shfmt: Shfmt) -> Setup:
         else setup_request.request.prior_formatter_result
     )
 
+    # The Process needs one single `Digest`, so we merge everything together. See
+    # https://www.pantsbuild.org/v2.0/docs/rules-api-file-system.
     input_digest = await Get(
         Digest,
         MergeDigests(
@@ -127,6 +136,8 @@ async def shfmt_lint(request: ShfmtRequest, shfmt: Shfmt) -> LintResults:
     if shfmt.options.skip:
         return LintResults()
     setup = await Get(Setup, SetupRequest(request, check_only=True))
+    # We use `FallibleProcessResult`, rather than `ProcessResult`, because we're okay with the
+    # Process failing.
     result = await Get(FallibleProcessResult, Process, setup.process)
     return LintResults(
         [LintResult.from_fallible_process_result(result, linter_name="shfmt")]

--- a/pants-plugins/examples/bash/lint/shfmt/subsystem.py
+++ b/pants-plugins/examples/bash/lint/shfmt/subsystem.py
@@ -1,7 +1,12 @@
 # Copyright 2020 Pants project contributors.
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-# Refer to https://www.pantsbuild.org/v2.0/docs/rules-api-installing-tools.
+"""Options for the shfmt auto-formatter.
+
+We use `ExternalTool` so that we can easily install the pre-compiled binary. See
+https://www.pantsbuild.org/v2.0/docs/rules-api-installing-tools and
+https://www.pantsbuild.org/v2.0/docs/rules-api-subsystems.
+"""
 
 from pants.core.util_rules.external_tool import ExternalTool
 from pants.engine.platform import Platform

--- a/pants-plugins/examples/bash/register.py
+++ b/pants-plugins/examples/bash/register.py
@@ -1,13 +1,23 @@
 # Copyright 2020 Pants project contributors.
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from examples.bash import create_binary, run_binary
-from examples.bash.target_types import BashBinary, BashLibrary
+"""The entry point for our `examples.bash` plugin.
+
+See https://www.pantsbuild.org/v2.0/docs/plugins-overview.
+"""
+
+from examples.bash import bash_setup, create_binary, run_binary, shunit2_test_runner
+from examples.bash.target_types import BashBinary, BashLibrary, BashTests
 
 
 def target_types():
-    return [BashBinary, BashLibrary]
+    return [BashBinary, BashLibrary, BashTests]
 
 
 def rules():
-    return [*create_binary.rules(), *run_binary.rules()]
+    return [
+        *bash_setup.rules(),
+        *create_binary.rules(),
+        *run_binary.rules(),
+        *shunit2_test_runner.rules(),
+    ]

--- a/pants-plugins/examples/bash/run_binary.py
+++ b/pants-plugins/examples/bash/run_binary.py
@@ -1,33 +1,35 @@
 # Copyright 2020 Pants project contributors.
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+"""See https://www.pantsbuild.org/v2.0/docs/plugins-run-goal.
+
+This plugin finds `bash` on the user's machine, gets all relevant
+dependencies for the binary target, then runs the equivalent of `bash
+my_script.sh`.
+"""
+
 from pants.core.goals.run import RunRequest
 from pants.core.target_types import FilesSources, ResourcesSources
 from pants.core.util_rules.source_files import SourceFiles, SourceFilesRequest
 from pants.engine.addresses import Addresses
-from pants.engine.process import BinaryPathRequest, BinaryPaths
 from pants.engine.rules import Get, MultiGet, collect_rules, rule
 from pants.engine.target import Sources, TransitiveTargets
 from pants.util.logging import LogLevel
 
+from examples.bash.bash_setup import BashProgram, BashSetup
 from examples.bash.create_binary import BashBinaryFieldSet
 from examples.bash.target_types import BashSources
 
 
 @rule(level=LogLevel.DEBUG)
-async def run_bash_binary(field_set: BashBinaryFieldSet) -> RunRequest:
-    bash_program_paths = await Get(
-        BinaryPaths,
-        BinaryPathRequest(binary_name="bash", search_path=["/bin", "/usr/bin"]),
-    )
-    if not bash_program_paths.first_path:
-        raise ValueError(
-            "Could not find the `bash` program on `/bin` or `/usr/bin`, so cannot run "
-            f"{field_set.address}."
-        )
-
+async def run_bash_binary(
+    field_set: BashBinaryFieldSet, bash_program: BashProgram, bash_setup: BashSetup
+) -> RunRequest:
     transitive_targets = await Get(TransitiveTargets, Addresses([field_set.address]))
 
+    # We need to include all relevant transitive dependencies in the environment. We also get the
+    # binary's sources so that we know the script name. See
+    # https://www.pantsbuild.org/v2.0/docs/rules-api-and-target-api.
     binary_sources_request = Get(SourceFiles, SourceFilesRequest([field_set.sources]))
     all_sources_request = Get(
         SourceFiles,
@@ -46,7 +48,8 @@ async def run_bash_binary(field_set: BashBinaryFieldSet) -> RunRequest:
 
     return RunRequest(
         digest=all_sources.snapshot.digest,
-        args=[bash_program_paths.first_path, script_name],
+        args=[bash_program.exe, script_name],
+        env=bash_setup.env_dict,
     )
 
 

--- a/pants-plugins/examples/bash/shunit2_test_runner.py
+++ b/pants-plugins/examples/bash/shunit2_test_runner.py
@@ -6,11 +6,11 @@
 This plugin uses the Shunit2 test runner script (https://github.com/kward/shunit2). Because the
 test runner is a simple Bash script, we simply download the file to be able to run it. Shunit2
 requires that tests have "source ./shunit2" at the bottom of the tests; as a convenience, our
-plugin uses file system operations to automatically add that line to any test files missing it.
+plugin uses filesystem operations to automatically add that line to any test files missing it.
 After setting up the source files (including finding all relevant transitive dependencies), we run
 the equivalent of `bash test_file.sh`.
 
-We must implement rules for both normal `test` and `test --debug`. To deduplicate, we have a
+We must implement rules for both normal `test` and `test --debug`. To avoid duplication, we have a
 common `TestSetup` type and rule to set up the test.
 """
 

--- a/pants-plugins/examples/bash/shunit2_test_runner.py
+++ b/pants-plugins/examples/bash/shunit2_test_runner.py
@@ -167,7 +167,7 @@ async def run_tests_with_shunit2(field_set: Shunit2FieldSet) -> TestResult:
 @rule(desc="Setup Shunit2 to run interactively", level=LogLevel.DEBUG)
 async def setup_shunit2_debug_test(field_set: Shunit2FieldSet) -> TestDebugRequest:
     setup = await Get(TestSetup, TestSetupRequest(field_set))
-    # We set up an InteractiveProcess, which will get run in the `@goal_rule` in `test.py`.
+    # We set up an InteractiveProcess, which will be executed in the `@goal_rule` in `test.py`.
     return TestDebugRequest(
         InteractiveProcess(
             argv=setup.process.argv,

--- a/pants-plugins/examples/bash/shunit2_test_runner.py
+++ b/pants-plugins/examples/bash/shunit2_test_runner.py
@@ -1,0 +1,181 @@
+# Copyright 2020 Pants project contributors.
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+"""See https://www.pantsbuild.org/v2.0/docs/plugins-test-goal.
+
+This plugin uses the Shunit2 test runner script (https://github.com/kward/shunit2). Because the
+test runner is a simple Bash script, we simply download the file to be able to run it. Shunit2
+requires that tests have "source ./shunit2" at the bottom of the tests; as a convenience, our
+plugin uses file system operations to automatically add that line to any test files missing it.
+After setting up the source files (including finding all relevant transitive dependencies), we run
+the equivalent of `bash test_file.sh`.
+
+We must implement rules for both normal `test` and `test --debug`. To deduplicate, we have a
+common `TestSetup` type and rule to set up the test.
+"""
+
+from dataclasses import dataclass
+
+from pants.core.goals.test import TestDebugRequest, TestFieldSet, TestResult
+from pants.core.target_types import FilesSources, ResourcesSources
+from pants.core.util_rules.source_files import SourceFiles, SourceFilesRequest
+from pants.engine.addresses import Addresses
+from pants.engine.fs import (
+    CreateDigest,
+    Digest,
+    DigestContents,
+    DownloadFile,
+    FileContent,
+    MergeDigests,
+)
+from pants.engine.process import FallibleProcessResult, InteractiveProcess, Process
+from pants.engine.rules import Get, MultiGet, collect_rules, rule
+from pants.engine.target import Dependencies, Sources, TransitiveTargets
+from pants.engine.unions import UnionRule
+from pants.util.logging import LogLevel
+
+from examples.bash.bash_setup import BashProgram, BashSetup
+from examples.bash.target_types import BashSources, BashTestSources
+
+
+@dataclass(frozen=True)
+class Shunit2FieldSet(TestFieldSet):
+    required_fields = (BashTestSources,)
+
+    sources: BashTestSources
+    dependencies: Dependencies
+
+
+@dataclass(frozen=True)
+class TestSetupRequest:
+    field_set: Shunit2FieldSet
+
+
+@dataclass(frozen=True)
+class TestSetup:
+    process: Process
+
+
+@rule(level=LogLevel.DEBUG)
+async def setup_shunit2_for_target(
+    request: TestSetupRequest, bash_program: BashProgram, bash_setup: BashSetup
+) -> TestSetup:
+    # Because shunit2 is a simple Bash file, we download it using `DownloadFile`. Normally, we
+    # would install the test runner through `ExternalTool`. See
+    # https://www.pantsbuild.org/v2.0/docs/rules-api-installing-tools and
+    # https://www.pantsbuild.org/v2.0/docs/rules-api-file-system.
+    shunit2_script_request = Get(
+        Digest,
+        DownloadFile(
+            url="https://raw.githubusercontent.com/kward/shunit2/b9102bb763cc603b3115ed30a5648bf950548097/shunit2",
+            expected_digest=Digest(
+                "1f11477b7948150d1ca50cdd41d89be4ed2acd137e26d2e0fe23966d0e272cc5",
+                40987,
+            ),
+        ),
+    )
+
+    transitive_targets_request = Get(
+        TransitiveTargets, Addresses([request.field_set.address])
+    )
+
+    shunit2_script, transitive_targets = await MultiGet(
+        shunit2_script_request, transitive_targets_request
+    )
+
+    # We need to include all relevant transitive dependencies in the environment. We also get the
+    # test's sources so that we can check that it has `source ./shunit2` at the bottom of it.
+    #
+    # Because we might modify the test files, we leave the tests out of
+    # `dependencies_source_files_request` by using `transitive_targets.dependencies` instead of
+    # `transitive_targets.closure`. This makes sure that we don't accidentally include the
+    # unmodified test files and the modified test files in the same input. See
+    # https://www.pantsbuild.org/v2.0/docs/rules-api-and-target-api.
+    dependencies_source_files_request = Get(
+        SourceFiles,
+        SourceFilesRequest(
+            (tgt.get(Sources) for tgt in transitive_targets.dependencies),
+            for_sources_types=(BashSources, FilesSources, ResourcesSources),
+        ),
+    )
+    test_source_files_request = Get(
+        SourceFiles, SourceFilesRequest([request.field_set.sources])
+    )
+    dependencies_source_files, test_source_files = await MultiGet(
+        dependencies_source_files_request, test_source_files_request
+    )
+
+    # To check if the test files already have `source ./shunit2` in them, we need to look at the
+    # actual file content. We use `DigestContents` for this, and then use `CreateDigest` to create
+    # a digest of the (possibly) updated test files. See
+    # https://www.pantsbuild.org/v2.0/docs/rules-api-file-system.
+    #
+    # Most test runners don't modify their test files like we do here, so most test runners can
+    # skip this step.
+    test_files_content = await Get(
+        DigestContents, Digest, test_source_files.snapshot.digest
+    )
+    updated_test_files_content = []
+    for file_content in test_files_content:
+        if (
+            b"source ./shunit2" in file_content.content
+            or b". ./shunit2" in file_content.content
+        ):
+            updated_test_files_content.append(file_content)
+        else:
+            updated_file_content = FileContent(
+                path=file_content.path,
+                content=file_content.content + b"\nsource ./shunit2\n",
+            )
+            updated_test_files_content.append(updated_file_content)
+    updated_test_source_files = await Get(
+        Digest, CreateDigest(updated_test_files_content)
+    )
+
+    # The Process needs one single `Digest`, so we merge everything together. See
+    # https://www.pantsbuild.org/v2.0/docs/rules-api-file-system.
+    input_digest = await Get(
+        Digest,
+        MergeDigests(
+            [
+                shunit2_script,
+                updated_test_source_files,
+                dependencies_source_files.snapshot.digest,
+            ]
+        ),
+    )
+
+    process = Process(
+        argv=[bash_program.exe, *test_source_files.snapshot.files],
+        input_digest=input_digest,
+        description=f"Run shunit2 on {request.field_set.address}.",
+        level=LogLevel.DEBUG,
+        env=bash_setup.env_dict,
+    )
+    return TestSetup(process)
+
+
+@rule(desc="Run tests with Shunit2", level=LogLevel.DEBUG)
+async def run_tests_with_shunit2(field_set: Shunit2FieldSet) -> TestResult:
+    setup = await Get(TestSetup, TestSetupRequest(field_set))
+    # We use `FallibleProcessResult`, rather than `ProcessResult`, because we're okay with the
+    # Process failing.
+    result = await Get(FallibleProcessResult, Process, setup.process)
+    return TestResult.from_fallible_process_result(result)
+
+
+@rule(desc="Setup Shunit2 to run interactively", level=LogLevel.DEBUG)
+async def setup_shunit2_debug_test(field_set: Shunit2FieldSet) -> TestDebugRequest:
+    setup = await Get(TestSetup, TestSetupRequest(field_set))
+    # We set up an InteractiveProcess, which will get run in the `@goal_rule` in `test.py`.
+    return TestDebugRequest(
+        InteractiveProcess(
+            argv=setup.process.argv,
+            # env=setup.process.env,
+            input_digest=setup.process.input_digest,
+        ),
+    )
+
+
+def rules():
+    return (*collect_rules(), UnionRule(TestFieldSet, Shunit2FieldSet))

--- a/pants-plugins/examples/bash/target_types.py
+++ b/pants-plugins/examples/bash/target_types.py
@@ -1,7 +1,11 @@
 # Copyright 2020 Pants project contributors.
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-# Refer to https://www.pantsbuild.org/v2.0/docs/target-api-concepts.
+"""Defines our target types for Bash.
+
+See https://www.pantsbuild.org/v2.0/docs/target-api-concepts. This uses a common Pants pattern of
+having distinct `library`, `binary`, and `tests` target types.
+"""
 
 from pants.engine.target import COMMON_TARGET_FIELDS, Dependencies, Sources, Target
 
@@ -29,3 +33,20 @@ class BashBinary(Target):
 
     alias = "bash_binary"
     core_fields = (*COMMON_TARGET_FIELDS, Dependencies, BashBinarySources)
+
+
+class BashTestSources(BashSources):
+    default = ("*_test.sh", "test_*.sh")
+
+
+class BashTests(Target):
+    """Bash tests that are run via `shunit2`.
+
+    Refer to https://github.com/kward/shunit2. Pants will automatically
+    add `source `./shunit2` to the bottom of your test file if it is not
+    already there, and it will ensure that the script is available as a
+    sibling to your test file.
+    """
+
+    alias = "bash_tests"
+    core_fields = (*COMMON_TARGET_FIELDS, Dependencies, BashTestSources)


### PR DESCRIPTION
Corresponds to https://www.pantsbuild.org/v2.0/docs/plugins-test-goal (WIP).

https://github.com/kward/shunit2 is a neat script to run tests with Bash. It simply requires having the script as a sibling file to your test file, then adding `source ./shunit2` at the bottom. Pants makes this even more convenient by ensuring that the script is always present as a sibling to your test file and by automatically adding `soruce ./shunit2` to the bottom of the file if it's not already present.

We add a `bash_setup.py` file so that users can set the `$PATH`, and so that we can factor out common code to find the `bash` program.

This PR also improves the documentation for the rest of this repo.