### PR TITLE
Add a `timeout` field for tests and respect `test --force`

### DIFF
--- a/pants-plugins/examples/bash/repl.py
+++ b/pants-plugins/examples/bash/repl.py
@@ -52,7 +52,7 @@ async def create_bash_repl_request(
     return ReplRequest(
         digest=sources.snapshot.digest,
         args=(bash_program.exe,),
-        env=bash_setup.env_dict,
+        extra_env=bash_setup.env_dict,
     )
 
 

--- a/pants-plugins/examples/bash/run_binary.py
+++ b/pants-plugins/examples/bash/run_binary.py
@@ -62,7 +62,7 @@ async def run_bash_binary(
     return RunRequest(
         digest=all_sources.snapshot.digest,
         args=[bash_program.exe, script_name],
-        env=bash_setup.env_dict,
+        extra_env=bash_setup.env_dict,
     )
 
 

--- a/pants-plugins/examples/bash/target_types.py
+++ b/pants-plugins/examples/bash/target_types.py
@@ -7,7 +7,13 @@ See https://www.pantsbuild.org/v2.0/docs/target-api-concepts. This uses a common
 having distinct `library`, `binary`, and `tests` target types.
 """
 
-from pants.engine.target import COMMON_TARGET_FIELDS, Dependencies, Sources, Target
+from pants.engine.target import (
+    COMMON_TARGET_FIELDS,
+    Dependencies,
+    IntField,
+    Sources,
+    Target,
+)
 
 
 class BashSources(Sources):
@@ -39,6 +45,15 @@ class BashTestSources(BashSources):
     default = ("*_test.sh", "test_*.sh")
 
 
+class BashTestTimeout(IntField):
+    """Whether to time out after a certain amount of time.
+
+    If unset, the test will never time out.
+    """
+
+    alias = "timeout"
+
+
 class BashTests(Target):
     """Bash tests that are run via `shunit2`.
 
@@ -49,4 +64,9 @@ class BashTests(Target):
     """
 
     alias = "bash_tests"
-    core_fields = (*COMMON_TARGET_FIELDS, Dependencies, BashTestSources)
+    core_fields = (
+        *COMMON_TARGET_FIELDS,
+        Dependencies,
+        BashTestSources,
+        BashTestTimeout,
+    )

--- a/pants.toml
+++ b/pants.toml
@@ -2,7 +2,7 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 [GLOBAL]
-pants_version = "2.0.0a0"
+pants_version = "2.0.0a1"
 
 # This allows us to activate our plugin from first-party sources, rather than using a published
 # plugin from PyPI.


### PR DESCRIPTION
The `timeout` field is a good demo of the Target API. And lots of plugin authors will likely want to use it.

Respecting `test --force` is a bug fix.