### PR TITLE
Upgrade to 2.0.0b0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,5 +21,4 @@ script:
   - ./pants lint '::'
   - ./pants test '::'
   # Smoke test that our `binary` implementation runs successfully.
-  # TODO: fixed by https://github.com/pantsbuild/pants/pull/10710.
-  # - ./pants binary '::'
+  - ./pants binary '::'

--- a/pants-plugins/examples/bash/bash_setup.py
+++ b/pants-plugins/examples/bash/bash_setup.py
@@ -83,7 +83,7 @@ async def run_bash_binary(bash_setup: BashSetup) -> BashProgram:
             "possibly modify the option `executable_search_paths` in the `[bash-setup]` options "
             "scope."
         )
-    return BashProgram(bash_program_paths.first_path)
+    return BashProgram(bash_program_paths.first_path.path)
 
 
 def rules():

--- a/pants-plugins/examples/bash/create_binary.py
+++ b/pants-plugins/examples/bash/create_binary.py
@@ -10,6 +10,7 @@ A more robust `binary` implementation will create a single file that is runnable
 PEX file or JAR file.
 """
 
+import os
 from dataclasses import dataclass
 
 from pants.core.goals.binary import BinaryFieldSet, CreatedBinary
@@ -65,12 +66,14 @@ async def create_bash_binary(
         ),
     )
 
-    output_filename = f"{field_set.address.target_name}.zip"
+    output_filename = os.path.join(
+        field_set.address.spec_path.replace(os.sep, "."), f"{field_set.address.target_name}.zip"
+    )
     result = await Get(
         ProcessResult,
         Process(
             argv=(
-                zip_program_paths.first_path,
+                zip_program_paths.first_path.path,
                 output_filename,
                 *sources.snapshot.files,
             ),

--- a/pants-plugins/examples/bash/create_binary.py
+++ b/pants-plugins/examples/bash/create_binary.py
@@ -67,7 +67,8 @@ async def create_bash_binary(
     )
 
     output_filename = os.path.join(
-        field_set.address.spec_path.replace(os.sep, "."), f"{field_set.address.target_name}.zip"
+        field_set.address.spec_path.replace(os.sep, "."),
+        f"{field_set.address.target_name}.zip",
     )
     result = await Get(
         ProcessResult,

--- a/pants.toml
+++ b/pants.toml
@@ -2,7 +2,7 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 [GLOBAL]
-pants_version = "2.0.0a1"
+pants_version = "2.0.0b0"
 
 # This allows us to activate our plugin from first-party sources, rather than using a published
 # plugin from PyPI.


### PR DESCRIPTION
There are two changes to the plugin API:

* binary should write to a disambiguated address.
* `BinaryPaths` now stores `BinaryPath` objects, rather than `str`.

The docs are updated for both.