### PR TITLE
Use the new `BinaryPathTest` mechanism

### DIFF
--- a/pants-plugins/examples/bash/bash_setup.py
+++ b/pants-plugins/examples/bash/bash_setup.py
@@ -8,7 +8,7 @@ import os
 from dataclasses import dataclass
 from typing import Tuple
 
-from pants.engine.process import BinaryPathRequest, BinaryPaths
+from pants.engine.process import BinaryPathRequest, BinaryPaths, BinaryPathTest
 from pants.engine.rules import Get, collect_rules, rule
 from pants.option.subsystem import Subsystem
 from pants.util.frozendict import FrozenDict
@@ -73,7 +73,11 @@ async def run_bash_binary(bash_setup: BashSetup) -> BashProgram:
     bash_program_paths = await Get(
         BinaryPaths,
         BinaryPathRequest(
-            binary_name="bash", search_path=bash_setup.executable_search_path
+            binary_name="bash",
+            search_path=bash_setup.executable_search_path,
+            # This will run `bash --version` to ensure it's a valid binary and to allow
+            # invalidating the cache if the version changes.
+            test=BinaryPathTest(args=["--version"]),
         ),
     )
     if not bash_program_paths.first_path:

--- a/pants-plugins/examples/bash/create_binary.py
+++ b/pants-plugins/examples/bash/create_binary.py
@@ -17,7 +17,13 @@ from pants.core.goals.binary import BinaryFieldSet, CreatedBinary
 from pants.core.target_types import FilesSources, ResourcesSources
 from pants.core.util_rules.source_files import SourceFiles, SourceFilesRequest
 from pants.engine.addresses import Addresses
-from pants.engine.process import BinaryPathRequest, BinaryPaths, Process, ProcessResult
+from pants.engine.process import (
+    BinaryPathRequest,
+    BinaryPaths,
+    BinaryPathTest,
+    Process,
+    ProcessResult,
+)
 from pants.engine.rules import Get, collect_rules, rule
 from pants.engine.target import Sources, TransitiveTargets
 from pants.engine.unions import UnionRule
@@ -44,7 +50,11 @@ async def create_bash_binary(
     zip_program_paths = await Get(
         BinaryPaths,
         BinaryPathRequest(
-            binary_name="zip", search_path=bash_setup.executable_search_path
+            binary_name="zip",
+            search_path=bash_setup.executable_search_path,
+            # This will run `zip --version` to ensure it's a valid binary and to allow
+            # invalidating the cache if the version changes.
+            test=BinaryPathTest(args=["-v"]),
         ),
     )
     if not zip_program_paths.first_path:


### PR DESCRIPTION
We explain now in our docs that this step is recommended for both validity and more accurate caching: https://www.pantsbuild.org/v2.0/docs/rules-api-installing-tools#binarypaths-find-already-installed-binaries

So, we should demonstrate it.